### PR TITLE
Add EE MMIO registers

### DIFF
--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -72,6 +72,7 @@ define ram offset=0x10003940 size=0x4   [ REG_VIF0_COL0            ];
 define ram offset=0x10003950 size=0x4   [ REG_VIF0_COL1            ];
 define ram offset=0x10003960 size=0x4   [ REG_VIF0_COL2            ];
 define ram offset=0x10003970 size=0x4   [ REG_VIF0_COL3            ];
+
 define ram offset=0x10003C00 size=0x4   [ REG_VIF1_STAT            ];
 define ram offset=0x10003C10 size=0x4   [ REG_VIF1_FBRST           ];
 define ram offset=0x10003C20 size=0x4   [ REG_VIF1_ERR             ];
@@ -95,6 +96,7 @@ define ram offset=0x10003D40 size=0x4   [ REG_VIF1_COL0            ];
 define ram offset=0x10003D50 size=0x4   [ REG_VIF1_COL1            ];
 define ram offset=0x10003D60 size=0x4   [ REG_VIF1_COL2            ];
 define ram offset=0x10003D70 size=0x4   [ REG_VIF1_COL3            ];
+
 define ram offset=0x10004000 size=0x8   [ REG_VIF0_FIFO            ];
 define ram offset=0x10005000 size=0x8   [ REG_VIF1_FIFO            ];
 

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -4,10 +4,23 @@
 
 # EE Timers
 
-define ram offset=0x10000000 size=0x100 [ REG_TIMER0 ];
-define ram offset=0x10000800 size=0x100 [ REG_TIMER1 ];
-define ram offset=0x10001000 size=0x100 [ REG_TIMER2 ];
-define ram offset=0x10001800 size=0x100 [ REG_TIMER3 ];
+define ram offset=0x10000000 size=0x4   [ REG_RCNT0_COUNT          ];
+define ram offset=0x10000010 size=0x4   [ REG_RCNT0_MODE           ];
+define ram offset=0x10000020 size=0x4   [ REG_RCNT0_TARGET         ];
+define ram offset=0x10000030 size=0x4   [ REG_RCNT0_HOLD           ];
+
+define ram offset=0x10000800 size=0x4   [ REG_RCNT1_COUNT          ];
+define ram offset=0x10000810 size=0x4   [ REG_RCNT1_MODE           ];
+define ram offset=0x10000820 size=0x4   [ REG_RCNT1_TARGET         ];
+define ram offset=0x10000830 size=0x4   [ REG_RCNT1_HOLD           ];
+
+define ram offset=0x10001000 size=0x4   [ REG_RCNT2_COUNT          ];
+define ram offset=0x10001010 size=0x4   [ REG_RCNT2_MODE           ];
+define ram offset=0x10001020 size=0x4   [ REG_RCNT2_TARGET         ];
+
+define ram offset=0x10001800 size=0x4   [ REG_RCNT3_COUNT          ];
+define ram offset=0x10001810 size=0x4   [ REG_RCNT3_MODE           ];
+define ram offset=0x10001820 size=0x4   [ REG_RCNT3_TARGET         ];
 
 # Image Processing Unit (IPU)
 
@@ -15,6 +28,7 @@ define ram offset=0x10002000 size=0x8   [ REG_IPU_CMD              ]; # IPU Comm
 define ram offset=0x10002010 size=0x4   [ REG_IPU_CTRL             ]; # IPU Control
 define ram offset=0x10002020 size=0x4   [ REG_IPU_BP               ]; # IPU bit pointer control
 define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP              ]; # Top of bitsteam
+
 define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO         ]; # Out FIFO (read)
 define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO          ]; # In FIFO (write)
 
@@ -30,7 +44,57 @@ define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3             ]; # Bits 96-
 define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT              ]; # Transfer status counter
 define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT            ]; # PATH3 transfer status counter
 define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG            ]; # Bits 0-31 of PATH3 tag when interrupted
+
 define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO             ];
+
+# VIF
+
+# Some of the sizes may be wrong.
+define ram offset=0x10003800 size=0x4   [ REG_VIF0_STAT            ];
+define ram offset=0x10003810 size=0x4   [ REG_VIF0_FBRST           ];
+define ram offset=0x10003820 size=0x4   [ REG_VIF0_ERR             ];
+define ram offset=0x10003830 size=0x4   [ REG_VIF0_MARK            ];
+define ram offset=0x10003840 size=0x4   [ REG_VIF0_CYCLE           ];
+define ram offset=0x10003850 size=0x4   [ REG_VIF0_MODE            ];
+define ram offset=0x10003860 size=0x4   [ REG_VIF0_NUM             ];
+define ram offset=0x10003870 size=0x4   [ REG_VIF0_MASK            ];
+define ram offset=0x10003880 size=0x4   [ REG_VIF0_CODE            ];
+define ram offset=0x10003890 size=0x4   [ REG_VIF0_ITOPS           ];
+define ram offset=0x100038D0 size=0x4   [ REG_VIF0_ITOP            ];
+define ram offset=0x100038E0 size=0x4   [ REG_VIF0_TOP             ];
+define ram offset=0x10003900 size=0x4   [ REG_VIF0_ROW0            ];
+define ram offset=0x10003910 size=0x4   [ REG_VIF0_ROW1            ];
+define ram offset=0x10003920 size=0x4   [ REG_VIF0_ROW2            ];
+define ram offset=0x10003930 size=0x4   [ REG_VIF0_ROW3            ];
+define ram offset=0x10003940 size=0x4   [ REG_VIF0_COL0            ];
+define ram offset=0x10003950 size=0x4   [ REG_VIF0_COL1            ];
+define ram offset=0x10003960 size=0x4   [ REG_VIF0_COL2            ];
+define ram offset=0x10003970 size=0x4   [ REG_VIF0_COL3            ];
+define ram offset=0x10003C00 size=0x4   [ REG_VIF1_STAT            ];
+define ram offset=0x10003C10 size=0x4   [ REG_VIF1_FBRST           ];
+define ram offset=0x10003C20 size=0x4   [ REG_VIF1_ERR             ];
+define ram offset=0x10003C30 size=0x4   [ REG_VIF1_MARK            ];
+define ram offset=0x10003C40 size=0x4   [ REG_VIF1_CYCLE           ];
+define ram offset=0x10003C50 size=0x4   [ REG_VIF1_MODE            ];
+define ram offset=0x10003C60 size=0x4   [ REG_VIF1_NUM             ];
+define ram offset=0x10003C70 size=0x4   [ REG_VIF1_MASK            ];
+define ram offset=0x10003C80 size=0x4   [ REG_VIF1_CODE            ];
+define ram offset=0x10003C90 size=0x4   [ REG_VIF1_ITOPS           ];
+define ram offset=0x10003Ca0 size=0x4   [ REG_VIF1_BASE            ];
+define ram offset=0x10003Cb0 size=0x4   [ REG_VIF1_OFST            ];
+define ram offset=0x10003Cc0 size=0x4   [ REG_VIF1_TOPS            ];
+define ram offset=0x10003cd0 size=0x4   [ REG_VIF1_ITOP            ];
+define ram offset=0x10003ce0 size=0x4   [ REG_VIF1_TOP             ];
+define ram offset=0x10003d00 size=0x4   [ REG_VIF1_ROW0            ];
+define ram offset=0x10003D10 size=0x4   [ REG_VIF1_ROW1            ];
+define ram offset=0x10003D20 size=0x4   [ REG_VIF1_ROW2            ];
+define ram offset=0x10003D30 size=0x4   [ REG_VIF1_ROW3            ];
+define ram offset=0x10003D40 size=0x4   [ REG_VIF1_COL0            ];
+define ram offset=0x10003D50 size=0x4   [ REG_VIF1_COL1            ];
+define ram offset=0x10003D60 size=0x4   [ REG_VIF1_COL2            ];
+define ram offset=0x10003D70 size=0x4   [ REG_VIF1_COL3            ];
+define ram offset=0x10004000 size=0x8   [ REG_VIF0_FIFO            ];
+define ram offset=0x10005000 size=0x8   [ REG_VIF1_FIFO            ];
 
 # DMA Controller (DMAC)
 
@@ -117,6 +181,18 @@ define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW         ]; # DMAC dis
 define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT            ]; # Interrupt status
 define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK            ]; # Interrupt mask
 
+# SIO
+
+# Some of the sizes may be wrong.
+define ram offset=0x1000F100 size=0x4   [ REG_SIO_LCR              ];
+define ram offset=0x1000F110 size=0x4   [ REG_SIO_LSR              ];
+define ram offset=0x1000F120 size=0x4   [ REG_SIO_IER              ];
+define ram offset=0x1000F130 size=0x4   [ REG_SIO_ISR              ];
+define ram offset=0x1000F140 size=0x4   [ REG_SIO_FCR              ];
+define ram offset=0x1000F150 size=0x4   [ REG_SIO_BGR              ];
+define ram offset=0x1000F180 size=0x1   [ REG_SIO_TXFIFO           ];
+define ram offset=0x1000F1C0 size=0x4   [ REG_SIO_RXFIFO           ];
+
 # Subsystem Interface (SIF)
 
 define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM            ]; # EE->IOP communication
@@ -124,6 +200,15 @@ define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM            ]; # IOP->EE 
 define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG           ]; # EE->IOP flags
 define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG           ]; # IOP->EE flags
 define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL          ]; # Control register
+define ram offset=0x1000F250 size=0x4   [ REG_SIF_F250             ];
+define ram offset=0x1000F260 size=0x4   [ REG_SIF_F260             ];
+define ram offset=0x1000F300 size=0x4   [ REG_SIF_F300             ];
+define ram offset=0x1000F380 size=0x4   [ REG_SIF_F380             ];
+
+# MCH
+
+define ram offset=0x1000F430 size=0x4   [ REG_MCH_RICM             ];
+define ram offset=0x1000F440 size=0x4   [ REG_MCH_DRD              ];
 
 # Privileged GS registers
 

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -10,12 +10,12 @@ define ram offset=0x10001800 size=0x100 [ REG_TIMER3 ];
 
 # Image Processing Unit (IPU)
 
-define ram offset=0x10002000 size=0x8   [ REG_IPU_COMMAND             ];
-define ram offset=0x10002010 size=0x4   [ REG_IPU_CONTROL             ];
-define ram offset=0x10002020 size=0x4   [ REG_IPU_BIT_POINTER_CONTROL ];
-define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP_OF_BITSTREAM    ];
-define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO_READ       ];
-define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO_WRITE       ];
+define ram offset=0x10002000 size=0x8   [ REG_IPU_CMD               ]; # IPU Command
+define ram offset=0x10002010 size=0x4   [ REG_IPU_CTRL              ]; # IPU Control
+define ram offset=0x10002020 size=0x4   [ REG_IPU_BP                ]; # IPU bit pointer control
+define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP               ]; # Top of bitsteam
+define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO          ]; # Out FIFO (read)
+define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO           ]; # In FIFO (write)
 
 # Graphics Interface (GIF)
 

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -1,5 +1,6 @@
 # MMIO registers
 # For reference: https://psi-rockin.github.io/ps2tek/
+#                https://github.com/PCSX2/pcsx2/blob/c783b6d7b56916f62de53e50828355b214159a08/pcsx2/Hw.h
 
 # EE Timers
 

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -1,6 +1,8 @@
 # MMIO registers
-# For reference: https://psi-rockin.github.io/ps2tek/
-#                https://github.com/PCSX2/pcsx2/blob/c783b6d7b56916f62de53e50828355b214159a08/pcsx2/Hw.h
+
+# For reference:
+#   https://psi-rockin.github.io/ps2tek/
+#   https://github.com/PCSX2/pcsx2/blob/c783b6d7b56916f62de53e50828355b214159a08/pcsx2/Hw.h
 
 # EE Timers
 

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -1,0 +1,89 @@
+# MMIO registers
+# For reference: https://psi-rockin.github.io/ps2tek/
+
+# EE Timers
+
+define ram offset=0x10000000 size=0x100 [ TIMER0 ];
+define ram offset=0x10000800 size=0x100 [ TIMER1 ];
+define ram offset=0x10001000 size=0x100 [ TIMER2 ];
+define ram offset=0x10001800 size=0x100 [ TIMER3 ];
+
+# Image Processing Unit (IPU)
+
+define ram offset=0x10002000 size=0x8   [ IPU_COMMAND ];
+define ram offset=0x10002010 size=0x4   [ IPU_CONTROL ];
+define ram offset=0x10002020 size=0x4   [ IPU_BIT_POINTER_CONTROL ];
+define ram offset=0x10002030 size=0x8   [ IPU_TOP_OF_BITSTREAM ];
+define ram offset=0x10007000 size=0x10  [ IPU_OUT_FIFO_READ ];
+define ram offset=0x10007010 size=0x10  [ IPU_IN_FIFO_WRITE ];
+
+# Graphics Interface (GIF)
+
+define ram offset=0x10003000 size=0x4   [ GIF_CTRL ];
+define ram offset=0x10003010 size=0x4   [ GIF_MODE ];
+define ram offset=0x10003020 size=0x4   [ GIF_STAT ];
+define ram offset=0x10003040 size=0x4   [ GIF_TAG0 ];
+define ram offset=0x10003050 size=0x4   [ GIF_TAG1 ];
+define ram offset=0x10003060 size=0x4   [ GIF_TAG2 ];
+define ram offset=0x10003070 size=0x4   [ GIF_TAG3 ];
+define ram offset=0x10003080 size=0x4   [ GIF_CNT ];
+define ram offset=0x10003090 size=0x4   [ GIF_P3CNT ];
+define ram offset=0x100030A0 size=0x4   [ GIF_P3TAG ];
+define ram offset=0x10006000 size=0x10  [ GIF_FIFO ];
+
+# DMA Controller (DMAC)
+
+define ram offset=0x10008000 size=0x100 [ DMAC_CHANNEL0_VIF0 ];
+define ram offset=0x10009000 size=0x100 [ DMAC_CHANNEL1_VIF1 ];
+define ram offset=0x1000A000 size=0x100 [ DMAC_CHANNEL2_GIF ];
+define ram offset=0x1000B000 size=0x100 [ DMAC_CHANNEL3_IPU_FROM ];
+define ram offset=0x1000B400 size=0x100 [ DMAC_CHANNEL4_IPU_TO ];
+define ram offset=0x1000C000 size=0x100 [ DMAC_CHANNEL5_SIF0 ];
+define ram offset=0x1000C400 size=0x100 [ DMAC_CHANNEL6_SIF1 ];
+define ram offset=0x1000C800 size=0x100 [ DMAC_CHANNEL7_SIF2 ];
+define ram offset=0x1000D000 size=0x100 [ DMAC_CHANNEL8_SPR_FROM ];
+define ram offset=0x1000D400 size=0x100 [ DMAC_CHANNEL9_SPR_TO ];
+define ram offset=0x1000E000 size=0x4   [ DMAC_CTRL ];
+define ram offset=0x1000E010 size=0x4   [ DMAC_STAT ];
+define ram offset=0x1000E020 size=0x4   [ DMAC_PCR ];
+define ram offset=0x1000E030 size=0x4   [ DMAC_SQWC ];
+define ram offset=0x1000E040 size=0x4   [ DMAC_RBSR ];
+define ram offset=0x1000E050 size=0x4   [ DMAC_RBOR ];
+define ram offset=0x1000E060 size=0x4   [ DMAC_STADR ];
+define ram offset=0x1000F520 size=0x4   [ DMAC_ENABLER ];
+define ram offset=0x1000F590 size=0x4   [ DMAC_ENABLEW ];
+
+# Interrupt Controller (INTC)
+
+define ram offset=0x1000F000 size=0x4   [ INTC_STAT ];
+define ram offset=0x1000F010 size=0x4   [ INTC_MASK ];
+
+# Subsystem Interface (SIF)
+
+define ram offset=0x1000F200 size=0x4   [ SIF_MSCOM ];
+define ram offset=0x1000F210 size=0x4   [ SIF_SMCOM ];
+define ram offset=0x1000F220 size=0x4   [ SIF_MSFLAG ];
+define ram offset=0x1000F230 size=0x4   [ SIF_SMFLAG ];
+define ram offset=0x1000F240 size=0x4   [ SIF_CONTROL ];
+
+# Privileged GS registers
+
+define ram offset=0x12000000 size=0x8   [ GS_PMODE ];
+define ram offset=0x12000010 size=0x8   [ GS_SMODE1 ];
+define ram offset=0x12000020 size=0x8   [ GS_SMODE2 ];
+define ram offset=0x12000030 size=0x8   [ GS_SRFSH ];
+define ram offset=0x12000040 size=0x8   [ GS_SYNCH1 ];
+define ram offset=0x12000050 size=0x8   [ GS_SYNCH2 ];
+define ram offset=0x12000060 size=0x8   [ GS_SYNCV ];
+define ram offset=0x12000070 size=0x8   [ GS_DISPFB1 ];
+define ram offset=0x12000080 size=0x8   [ GS_DISPLAY1 ];
+define ram offset=0x12000090 size=0x8   [ GS_DISPFB2 ];
+define ram offset=0x120000A0 size=0x8   [ GS_DISPLAY2 ];
+define ram offset=0x120000B0 size=0x8   [ GS_EXTBUF ];
+define ram offset=0x120000C0 size=0x8   [ GS_EXTDATA ];
+define ram offset=0x120000D0 size=0x8   [ GS_EXTWRITE ];
+define ram offset=0x120000E0 size=0x8   [ GS_BGCOLOR ];
+define ram offset=0x12001000 size=0x8   [ GS_GS_CSR ];
+define ram offset=0x12001010 size=0x8   [ GS_GS_IMR ];
+define ram offset=0x12001040 size=0x8   [ GS_BUSDIR ];
+define ram offset=0x12001080 size=0x8   [ GS_SIGLBLID ];

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -3,145 +3,145 @@
 
 # EE Timers
 
-define ram offset=0x10000000 size=0x100 [ TIMER0 ];
-define ram offset=0x10000800 size=0x100 [ TIMER1 ];
-define ram offset=0x10001000 size=0x100 [ TIMER2 ];
-define ram offset=0x10001800 size=0x100 [ TIMER3 ];
+define ram offset=0x10000000 size=0x100 [ REG_TIMER0 ];
+define ram offset=0x10000800 size=0x100 [ REG_TIMER1 ];
+define ram offset=0x10001000 size=0x100 [ REG_TIMER2 ];
+define ram offset=0x10001800 size=0x100 [ REG_TIMER3 ];
 
 # Image Processing Unit (IPU)
 
-define ram offset=0x10002000 size=0x8   [ IPU_COMMAND ];
-define ram offset=0x10002010 size=0x4   [ IPU_CONTROL ];
-define ram offset=0x10002020 size=0x4   [ IPU_BIT_POINTER_CONTROL ];
-define ram offset=0x10002030 size=0x8   [ IPU_TOP_OF_BITSTREAM ];
-define ram offset=0x10007000 size=0x10  [ IPU_OUT_FIFO_READ ];
-define ram offset=0x10007010 size=0x10  [ IPU_IN_FIFO_WRITE ];
+define ram offset=0x10002000 size=0x8   [ REG_IPU_COMMAND ];
+define ram offset=0x10002010 size=0x4   [ REG_IPU_CONTROL ];
+define ram offset=0x10002020 size=0x4   [ REG_IPU_BIT_POINTER_CONTROL ];
+define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP_OF_BITSTREAM ];
+define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO_READ ];
+define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO_WRITE ];
 
 # Graphics Interface (GIF)
 
-define ram offset=0x10003000 size=0x4   [ GIF_CTRL ];
-define ram offset=0x10003010 size=0x4   [ GIF_MODE ];
-define ram offset=0x10003020 size=0x4   [ GIF_STAT ];
-define ram offset=0x10003040 size=0x4   [ GIF_TAG0 ];
-define ram offset=0x10003050 size=0x4   [ GIF_TAG1 ];
-define ram offset=0x10003060 size=0x4   [ GIF_TAG2 ];
-define ram offset=0x10003070 size=0x4   [ GIF_TAG3 ];
-define ram offset=0x10003080 size=0x4   [ GIF_CNT ];
-define ram offset=0x10003090 size=0x4   [ GIF_P3CNT ];
-define ram offset=0x100030A0 size=0x4   [ GIF_P3TAG ];
-define ram offset=0x10006000 size=0x10  [ GIF_FIFO ];
+define ram offset=0x10003000 size=0x4   [ REG_GIF_CTRL ];
+define ram offset=0x10003010 size=0x4   [ REG_GIF_MODE ];
+define ram offset=0x10003020 size=0x4   [ REG_GIF_STAT ];
+define ram offset=0x10003040 size=0x4   [ REG_GIF_TAG0 ];
+define ram offset=0x10003050 size=0x4   [ REG_GIF_TAG1 ];
+define ram offset=0x10003060 size=0x4   [ REG_GIF_TAG2 ];
+define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3 ];
+define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT ];
+define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT ];
+define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG ];
+define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO ];
 
 # DMA Controller (DMAC)
 
 # Channel 0
-define ram offset=0x10008000 size=0x4   [ DMAC_0_VIF0_CHCR      ]; # Channel control.
-define ram offset=0x10008010 size=0x4   [ DMAC_0_VIF0_MADR      ]; # Channel address.
-define ram offset=0x10008020 size=0x4   [ DMAC_0_VIF0_QWC       ]; # Quadword count.
-define ram offset=0x10008030 size=0x4   [ DMAC_0_VIF0_TADR      ]; # Channel tag address.
-define ram offset=0x10008040 size=0x4   [ DMAC_0_VIF0_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x10008050 size=0x4   [ DMAC_0_VIF0_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10008000 size=0x4   [ REG_DMAC_0_VIF0_CHCR      ]; # Channel control.
+define ram offset=0x10008010 size=0x4   [ REG_DMAC_0_VIF0_MADR      ]; # Channel address.
+define ram offset=0x10008020 size=0x4   [ REG_DMAC_0_VIF0_QWC       ]; # Quadword count.
+define ram offset=0x10008030 size=0x4   [ REG_DMAC_0_VIF0_TADR      ]; # Channel tag address.
+define ram offset=0x10008040 size=0x4   [ REG_DMAC_0_VIF0_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10008050 size=0x4   [ REG_DMAC_0_VIF0_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
 
 # Channel 1
-define ram offset=0x10009000 size=0x4   [ DMAC_1_VIF1_CHCR      ]; # Channel control.
-define ram offset=0x10009010 size=0x4   [ DMAC_1_VIF1_MADR      ]; # Channel address.
-define ram offset=0x10009020 size=0x4   [ DMAC_1_VIF1_QWC       ]; # Quadword count.
-define ram offset=0x10009030 size=0x4   [ DMAC_1_VIF1_TADR      ]; # Channel tag address.
-define ram offset=0x10009040 size=0x4   [ DMAC_1_VIF1_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x10009050 size=0x4   [ DMAC_1_VIF1_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10009000 size=0x4   [ REG_DMAC_1_VIF1_CHCR      ]; # Channel control.
+define ram offset=0x10009010 size=0x4   [ REG_DMAC_1_VIF1_MADR      ]; # Channel address.
+define ram offset=0x10009020 size=0x4   [ REG_DMAC_1_VIF1_QWC       ]; # Quadword count.
+define ram offset=0x10009030 size=0x4   [ REG_DMAC_1_VIF1_TADR      ]; # Channel tag address.
+define ram offset=0x10009040 size=0x4   [ REG_DMAC_1_VIF1_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10009050 size=0x4   [ REG_DMAC_1_VIF1_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
 
 # Channel 2
-define ram offset=0x1000A000 size=0x4   [ DMAC_2_GIF_CHCR       ]; # Channel control.
-define ram offset=0x1000A010 size=0x4   [ DMAC_2_GIF_MADR       ]; # Channel address.
-define ram offset=0x1000A020 size=0x4   [ DMAC_2_GIF_QWC        ]; # Quadword count.
-define ram offset=0x1000A030 size=0x4   [ DMAC_2_GIF_TADR       ]; # Channel tag address.
-define ram offset=0x1000A040 size=0x4   [ DMAC_2_GIF_ASR0       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x1000A050 size=0x4   [ DMAC_2_GIF_ASR1       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x1000A000 size=0x4   [ REG_DMAC_2_GIF_CHCR       ]; # Channel control.
+define ram offset=0x1000A010 size=0x4   [ REG_DMAC_2_GIF_MADR       ]; # Channel address.
+define ram offset=0x1000A020 size=0x4   [ REG_DMAC_2_GIF_QWC        ]; # Quadword count.
+define ram offset=0x1000A030 size=0x4   [ REG_DMAC_2_GIF_TADR       ]; # Channel tag address.
+define ram offset=0x1000A040 size=0x4   [ REG_DMAC_2_GIF_ASR0       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x1000A050 size=0x4   [ REG_DMAC_2_GIF_ASR1       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
 
 # Channel 3
-define ram offset=0x1000B000 size=0x4   [ DMAC_3_IPU_FROM_CHCR  ]; # Channel control.
-define ram offset=0x1000B010 size=0x4   [ DMAC_3_IPU_FROM_MADR  ]; # Channel address.
-define ram offset=0x1000B020 size=0x4   [ DMAC_3_IPU_FROM_QWC   ]; # Quadword count.
-define ram offset=0x1000B030 size=0x4   [ DMAC_3_IPU_FROM_TADR  ]; # Channel tag address.
+define ram offset=0x1000B000 size=0x4   [ REG_DMAC_3_IPU_FROM_CHCR  ]; # Channel control.
+define ram offset=0x1000B010 size=0x4   [ REG_DMAC_3_IPU_FROM_MADR  ]; # Channel address.
+define ram offset=0x1000B020 size=0x4   [ REG_DMAC_3_IPU_FROM_QWC   ]; # Quadword count.
+define ram offset=0x1000B030 size=0x4   [ REG_DMAC_3_IPU_FROM_TADR  ]; # Channel tag address.
 
 # Channel 4
-define ram offset=0x1000B400 size=0x4   [ DMAC_4_IPU_TO_CHCR    ]; # Channel control.
-define ram offset=0x1000B410 size=0x4   [ DMAC_4_IPU_TO_MADR    ]; # Channel address.
-define ram offset=0x1000B420 size=0x4   [ DMAC_4_IPU_TO_QWC     ]; # Quadword count.
-define ram offset=0x1000B430 size=0x4   [ DMAC_4_IPU_TO_TADR    ]; # Channel tag address.
+define ram offset=0x1000B400 size=0x4   [ REG_DMAC_4_IPU_TO_CHCR    ]; # Channel control.
+define ram offset=0x1000B410 size=0x4   [ REG_DMAC_4_IPU_TO_MADR    ]; # Channel address.
+define ram offset=0x1000B420 size=0x4   [ REG_DMAC_4_IPU_TO_QWC     ]; # Quadword count.
+define ram offset=0x1000B430 size=0x4   [ REG_DMAC_4_IPU_TO_TADR    ]; # Channel tag address.
 
 # Channel 5
-define ram offset=0x1000C000 size=0x4   [ DMAC_5_SIF0_CHCR      ]; # Channel control.
-define ram offset=0x1000C010 size=0x4   [ DMAC_5_SIF0_MADR      ]; # Channel address.
-define ram offset=0x1000C020 size=0x4   [ DMAC_5_SIF0_QWC       ]; # Quadword count.
-define ram offset=0x1000C030 size=0x4   [ DMAC_5_SIF0_TADR      ]; # Channel tag address.
+define ram offset=0x1000C000 size=0x4   [ REG_DMAC_5_SIF0_CHCR      ]; # Channel control.
+define ram offset=0x1000C010 size=0x4   [ REG_DMAC_5_SIF0_MADR      ]; # Channel address.
+define ram offset=0x1000C020 size=0x4   [ REG_DMAC_5_SIF0_QWC       ]; # Quadword count.
+define ram offset=0x1000C030 size=0x4   [ REG_DMAC_5_SIF0_TADR      ]; # Channel tag address.
 
 # Channel 6
-define ram offset=0x1000C400 size=0x4   [ DMAC_6_SIF1_CHCR      ]; # Channel control.
-define ram offset=0x1000C410 size=0x4   [ DMAC_6_SIF1_MADR      ]; # Channel address.
-define ram offset=0x1000C420 size=0x4   [ DMAC_6_SIF1_QWC       ]; # Quadword count.
-define ram offset=0x1000C430 size=0x4   [ DMAC_6_SIF1_TADR      ]; # Channel tag address.
+define ram offset=0x1000C400 size=0x4   [ REG_DMAC_6_SIF1_CHCR      ]; # Channel control.
+define ram offset=0x1000C410 size=0x4   [ REG_DMAC_6_SIF1_MADR      ]; # Channel address.
+define ram offset=0x1000C420 size=0x4   [ REG_DMAC_6_SIF1_QWC       ]; # Quadword count.
+define ram offset=0x1000C430 size=0x4   [ REG_DMAC_6_SIF1_TADR      ]; # Channel tag address.
 
 # Channel 7
-define ram offset=0x1000C800 size=0x4   [ DMAC_7_SIF2_CHCR      ]; # Channel control.
-define ram offset=0x1000C810 size=0x4   [ DMAC_7_SIF2_MADR      ]; # Channel address.
-define ram offset=0x1000C820 size=0x4   [ DMAC_7_SIF2_QWC       ]; # Quadword count.
-define ram offset=0x1000C830 size=0x4   [ DMAC_7_SIF2_TADR      ]; # Channel tag address.
+define ram offset=0x1000C800 size=0x4   [ REG_DMAC_7_SIF2_CHCR      ]; # Channel control.
+define ram offset=0x1000C810 size=0x4   [ REG_DMAC_7_SIF2_MADR      ]; # Channel address.
+define ram offset=0x1000C820 size=0x4   [ REG_DMAC_7_SIF2_QWC       ]; # Quadword count.
+define ram offset=0x1000C830 size=0x4   [ REG_DMAC_7_SIF2_TADR      ]; # Channel tag address.
 
 # Channel 8
-define ram offset=0x1000D000 size=0x4   [ DMAC_8_SPR_FROM_CHCR  ]; # Channel control.
-define ram offset=0x1000D010 size=0x4   [ DMAC_8_SPR_FROM_MADR  ]; # Channel address.
-define ram offset=0x1000D020 size=0x4   [ DMAC_8_SPR_FROM_QWC   ]; # Quadword count.
-define ram offset=0x1000D030 size=0x4   [ DMAC_8_SPR_FROM_TADR  ]; # Channel tag address.
-define ram offset=0x1000D080 size=0x4   [ DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+define ram offset=0x1000D000 size=0x4   [ REG_DMAC_8_SPR_FROM_CHCR  ]; # Channel control.
+define ram offset=0x1000D010 size=0x4   [ REG_DMAC_8_SPR_FROM_MADR  ]; # Channel address.
+define ram offset=0x1000D020 size=0x4   [ REG_DMAC_8_SPR_FROM_QWC   ]; # Quadword count.
+define ram offset=0x1000D030 size=0x4   [ REG_DMAC_8_SPR_FROM_TADR  ]; # Channel tag address.
+define ram offset=0x1000D080 size=0x4   [ REG_DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
 
 # Channel 9
-define ram offset=0x1000D400 size=0x4   [ DMAC_9_SPR_TO_CHCR    ]; # Channel control.
-define ram offset=0x1000D410 size=0x4   [ DMAC_9_SPR_TO_MADR    ]; # Channel address.
-define ram offset=0x1000D420 size=0x4   [ DMAC_9_SPR_TO_QWC     ]; # Quadword count.
-define ram offset=0x1000D430 size=0x4   [ DMAC_9_SPR_TO_TADR    ]; # Channel tag address.
-define ram offset=0x1000D480 size=0x4   [ DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+define ram offset=0x1000D400 size=0x4   [ REG_DMAC_9_SPR_TO_CHCR    ]; # Channel control.
+define ram offset=0x1000D410 size=0x4   [ REG_DMAC_9_SPR_TO_MADR    ]; # Channel address.
+define ram offset=0x1000D420 size=0x4   [ REG_DMAC_9_SPR_TO_QWC     ]; # Quadword count.
+define ram offset=0x1000D430 size=0x4   [ REG_DMAC_9_SPR_TO_TADR    ]; # Channel tag address.
+define ram offset=0x1000D480 size=0x4   [ REG_DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
 
-define ram offset=0x1000E000 size=0x4   [ DMAC_CTRL ];
-define ram offset=0x1000E010 size=0x4   [ DMAC_STAT ];
-define ram offset=0x1000E020 size=0x4   [ DMAC_PCR ];
-define ram offset=0x1000E030 size=0x4   [ DMAC_SQWC ];
-define ram offset=0x1000E040 size=0x4   [ DMAC_RBSR ];
-define ram offset=0x1000E050 size=0x4   [ DMAC_RBOR ];
-define ram offset=0x1000E060 size=0x4   [ DMAC_STADR ];
-define ram offset=0x1000F520 size=0x4   [ DMAC_ENABLER ];
-define ram offset=0x1000F590 size=0x4   [ DMAC_ENABLEW ];
+define ram offset=0x1000E000 size=0x4   [ REG_DMAC_CTRL ];
+define ram offset=0x1000E010 size=0x4   [ REG_DMAC_STAT ];
+define ram offset=0x1000E020 size=0x4   [ REG_DMAC_PCR ];
+define ram offset=0x1000E030 size=0x4   [ REG_DMAC_SQWC ];
+define ram offset=0x1000E040 size=0x4   [ REG_DMAC_RBSR ];
+define ram offset=0x1000E050 size=0x4   [ REG_DMAC_RBOR ];
+define ram offset=0x1000E060 size=0x4   [ REG_DMAC_STADR ];
+define ram offset=0x1000F520 size=0x4   [ REG_DMAC_ENABLER ];
+define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW ];
 
 # Interrupt Controller (INTC)
 
-define ram offset=0x1000F000 size=0x4   [ INTC_STAT ];
-define ram offset=0x1000F010 size=0x4   [ INTC_MASK ];
+define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT ];
+define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK ];
 
 # Subsystem Interface (SIF)
 
-define ram offset=0x1000F200 size=0x4   [ SIF_MSCOM ];
-define ram offset=0x1000F210 size=0x4   [ SIF_SMCOM ];
-define ram offset=0x1000F220 size=0x4   [ SIF_MSFLAG ];
-define ram offset=0x1000F230 size=0x4   [ SIF_SMFLAG ];
-define ram offset=0x1000F240 size=0x4   [ SIF_CONTROL ];
+define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM ];
+define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM ];
+define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG ];
+define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG ];
+define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL ];
 
 # Privileged GS registers
 
-define ram offset=0x12000000 size=0x8   [ GS_PMODE ];
-define ram offset=0x12000010 size=0x8   [ GS_SMODE1 ];
-define ram offset=0x12000020 size=0x8   [ GS_SMODE2 ];
-define ram offset=0x12000030 size=0x8   [ GS_SRFSH ];
-define ram offset=0x12000040 size=0x8   [ GS_SYNCH1 ];
-define ram offset=0x12000050 size=0x8   [ GS_SYNCH2 ];
-define ram offset=0x12000060 size=0x8   [ GS_SYNCV ];
-define ram offset=0x12000070 size=0x8   [ GS_DISPFB1 ];
-define ram offset=0x12000080 size=0x8   [ GS_DISPLAY1 ];
-define ram offset=0x12000090 size=0x8   [ GS_DISPFB2 ];
-define ram offset=0x120000A0 size=0x8   [ GS_DISPLAY2 ];
-define ram offset=0x120000B0 size=0x8   [ GS_EXTBUF ];
-define ram offset=0x120000C0 size=0x8   [ GS_EXTDATA ];
-define ram offset=0x120000D0 size=0x8   [ GS_EXTWRITE ];
-define ram offset=0x120000E0 size=0x8   [ GS_BGCOLOR ];
-define ram offset=0x12001000 size=0x8   [ GS_GS_CSR ];
-define ram offset=0x12001010 size=0x8   [ GS_GS_IMR ];
-define ram offset=0x12001040 size=0x8   [ GS_BUSDIR ];
-define ram offset=0x12001080 size=0x8   [ GS_SIGLBLID ];
+define ram offset=0x12000000 size=0x8   [ REG_GS_PMODE ];
+define ram offset=0x12000010 size=0x8   [ REG_GS_SMODE1 ];
+define ram offset=0x12000020 size=0x8   [ REG_GS_SMODE2 ];
+define ram offset=0x12000030 size=0x8   [ REG_GS_SRFSH ];
+define ram offset=0x12000040 size=0x8   [ REG_GS_SYNCH1 ];
+define ram offset=0x12000050 size=0x8   [ REG_GS_SYNCH2 ];
+define ram offset=0x12000060 size=0x8   [ REG_GS_SYNCV ];
+define ram offset=0x12000070 size=0x8   [ REG_GS_DISPFB1 ];
+define ram offset=0x12000080 size=0x8   [ REG_GS_DISPLAY1 ];
+define ram offset=0x12000090 size=0x8   [ REG_GS_DISPFB2 ];
+define ram offset=0x120000A0 size=0x8   [ REG_GS_DISPLAY2 ];
+define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF ];
+define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA ];
+define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE ];
+define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR ];
+define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR ];
+define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR ];
+define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR ];
+define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID ];

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -141,7 +141,7 @@ define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF            ];
 define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA           ];
 define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE          ];
 define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR           ]; # background color
-define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR            ]; # control register
-define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR            ]; # GS interrupt control
+define ram offset=0x12001000 size=0x8   [ REG_GS_CSR               ]; # control register
+define ram offset=0x12001010 size=0x8   [ REG_GS_IMR               ]; # GS interrupt control
 define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR            ]; # transfer direction
 define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID          ]; # signal

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -33,16 +33,74 @@ define ram offset=0x10006000 size=0x10  [ GIF_FIFO ];
 
 # DMA Controller (DMAC)
 
-define ram offset=0x10008000 size=0x100 [ DMAC_CHANNEL0_VIF0 ];
-define ram offset=0x10009000 size=0x100 [ DMAC_CHANNEL1_VIF1 ];
-define ram offset=0x1000A000 size=0x100 [ DMAC_CHANNEL2_GIF ];
-define ram offset=0x1000B000 size=0x100 [ DMAC_CHANNEL3_IPU_FROM ];
-define ram offset=0x1000B400 size=0x100 [ DMAC_CHANNEL4_IPU_TO ];
-define ram offset=0x1000C000 size=0x100 [ DMAC_CHANNEL5_SIF0 ];
-define ram offset=0x1000C400 size=0x100 [ DMAC_CHANNEL6_SIF1 ];
-define ram offset=0x1000C800 size=0x100 [ DMAC_CHANNEL7_SIF2 ];
-define ram offset=0x1000D000 size=0x100 [ DMAC_CHANNEL8_SPR_FROM ];
-define ram offset=0x1000D400 size=0x100 [ DMAC_CHANNEL9_SPR_TO ];
+# Channel 0
+define ram offset=0x10008000 size=0x4   [ DMAC_0_VIF0_CHCR      ]; # Channel control.
+define ram offset=0x10008010 size=0x4   [ DMAC_0_VIF0_MADR      ]; # Channel address.
+define ram offset=0x10008020 size=0x4   [ DMAC_0_VIF0_QWC       ]; # Quadword count.
+define ram offset=0x10008030 size=0x4   [ DMAC_0_VIF0_TADR      ]; # Channel tag address.
+define ram offset=0x10008040 size=0x4   [ DMAC_0_VIF0_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10008050 size=0x4   [ DMAC_0_VIF0_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+
+# Channel 1
+define ram offset=0x10009000 size=0x4   [ DMAC_1_VIF1_CHCR      ]; # Channel control.
+define ram offset=0x10009010 size=0x4   [ DMAC_1_VIF1_MADR      ]; # Channel address.
+define ram offset=0x10009020 size=0x4   [ DMAC_1_VIF1_QWC       ]; # Quadword count.
+define ram offset=0x10009030 size=0x4   [ DMAC_1_VIF1_TADR      ]; # Channel tag address.
+define ram offset=0x10009040 size=0x4   [ DMAC_1_VIF1_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10009050 size=0x4   [ DMAC_1_VIF1_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+
+# Channel 2
+define ram offset=0x1000A000 size=0x4   [ DMAC_2_GIF_CHCR       ]; # Channel control.
+define ram offset=0x1000A010 size=0x4   [ DMAC_2_GIF_MADR       ]; # Channel address.
+define ram offset=0x1000A020 size=0x4   [ DMAC_2_GIF_QWC        ]; # Quadword count.
+define ram offset=0x1000A030 size=0x4   [ DMAC_2_GIF_TADR       ]; # Channel tag address.
+define ram offset=0x1000A040 size=0x4   [ DMAC_2_GIF_ASR0       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x1000A050 size=0x4   [ DMAC_2_GIF_ASR1       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+
+# Channel 3
+define ram offset=0x1000B000 size=0x4   [ DMAC_3_IPU_FROM_CHCR  ]; # Channel control.
+define ram offset=0x1000B010 size=0x4   [ DMAC_3_IPU_FROM_MADR  ]; # Channel address.
+define ram offset=0x1000B020 size=0x4   [ DMAC_3_IPU_FROM_QWC   ]; # Quadword count.
+define ram offset=0x1000B030 size=0x4   [ DMAC_3_IPU_FROM_TADR  ]; # Channel tag address.
+
+# Channel 4
+define ram offset=0x1000B400 size=0x4   [ DMAC_4_IPU_TO_CHCR    ]; # Channel control.
+define ram offset=0x1000B410 size=0x4   [ DMAC_4_IPU_TO_MADR    ]; # Channel address.
+define ram offset=0x1000B420 size=0x4   [ DMAC_4_IPU_TO_QWC     ]; # Quadword count.
+define ram offset=0x1000B430 size=0x4   [ DMAC_4_IPU_TO_TADR    ]; # Channel tag address.
+
+# Channel 5
+define ram offset=0x1000C000 size=0x4   [ DMAC_5_SIF0_CHCR      ]; # Channel control.
+define ram offset=0x1000C010 size=0x4   [ DMAC_5_SIF0_MADR      ]; # Channel address.
+define ram offset=0x1000C020 size=0x4   [ DMAC_5_SIF0_QWC       ]; # Quadword count.
+define ram offset=0x1000C030 size=0x4   [ DMAC_5_SIF0_TADR      ]; # Channel tag address.
+
+# Channel 6
+define ram offset=0x1000C400 size=0x4   [ DMAC_6_SIF1_CHCR      ]; # Channel control.
+define ram offset=0x1000C410 size=0x4   [ DMAC_6_SIF1_MADR      ]; # Channel address.
+define ram offset=0x1000C420 size=0x4   [ DMAC_6_SIF1_QWC       ]; # Quadword count.
+define ram offset=0x1000C430 size=0x4   [ DMAC_6_SIF1_TADR      ]; # Channel tag address.
+
+# Channel 7
+define ram offset=0x1000C800 size=0x4   [ DMAC_7_SIF2_CHCR      ]; # Channel control.
+define ram offset=0x1000C810 size=0x4   [ DMAC_7_SIF2_MADR      ]; # Channel address.
+define ram offset=0x1000C820 size=0x4   [ DMAC_7_SIF2_QWC       ]; # Quadword count.
+define ram offset=0x1000C830 size=0x4   [ DMAC_7_SIF2_TADR      ]; # Channel tag address.
+
+# Channel 8
+define ram offset=0x1000D000 size=0x4   [ DMAC_8_SPR_FROM_CHCR  ]; # Channel control.
+define ram offset=0x1000D010 size=0x4   [ DMAC_8_SPR_FROM_MADR  ]; # Channel address.
+define ram offset=0x1000D020 size=0x4   [ DMAC_8_SPR_FROM_QWC   ]; # Quadword count.
+define ram offset=0x1000D030 size=0x4   [ DMAC_8_SPR_FROM_TADR  ]; # Channel tag address.
+define ram offset=0x1000D080 size=0x4   [ DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+
+# Channel 9
+define ram offset=0x1000D400 size=0x4   [ DMAC_9_SPR_TO_CHCR    ]; # Channel control.
+define ram offset=0x1000D410 size=0x4   [ DMAC_9_SPR_TO_MADR    ]; # Channel address.
+define ram offset=0x1000D420 size=0x4   [ DMAC_9_SPR_TO_QWC     ]; # Quadword count.
+define ram offset=0x1000D430 size=0x4   [ DMAC_9_SPR_TO_TADR    ]; # Channel tag address.
+define ram offset=0x1000D480 size=0x4   [ DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+
 define ram offset=0x1000E000 size=0x4   [ DMAC_CTRL ];
 define ram offset=0x1000E010 size=0x4   [ DMAC_STAT ];
 define ram offset=0x1000E020 size=0x4   [ DMAC_PCR ];

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -10,138 +10,138 @@ define ram offset=0x10001800 size=0x100 [ REG_TIMER3 ];
 
 # Image Processing Unit (IPU)
 
-define ram offset=0x10002000 size=0x8   [ REG_IPU_CMD               ]; # IPU Command
-define ram offset=0x10002010 size=0x4   [ REG_IPU_CTRL              ]; # IPU Control
-define ram offset=0x10002020 size=0x4   [ REG_IPU_BP                ]; # IPU bit pointer control
-define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP               ]; # Top of bitsteam
-define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO          ]; # Out FIFO (read)
-define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO           ]; # In FIFO (write)
+define ram offset=0x10002000 size=0x8   [ REG_IPU_CMD              ]; # IPU Command
+define ram offset=0x10002010 size=0x4   [ REG_IPU_CTRL             ]; # IPU Control
+define ram offset=0x10002020 size=0x4   [ REG_IPU_BP               ]; # IPU bit pointer control
+define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP              ]; # Top of bitsteam
+define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO         ]; # Out FIFO (read)
+define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO          ]; # In FIFO (write)
 
 # Graphics Interface (GIF)
 
-define ram offset=0x10003000 size=0x4   [ REG_GIF_CTRL              ]; # Control register
-define ram offset=0x10003010 size=0x4   [ REG_GIF_MODE              ]; # Mode setting
-define ram offset=0x10003020 size=0x4   [ REG_GIF_STAT              ]; # Status
-define ram offset=0x10003040 size=0x4   [ REG_GIF_TAG0              ]; # Bits 0-31 of tag before
-define ram offset=0x10003050 size=0x4   [ REG_GIF_TAG1              ]; # Bits 32-63 of tag before
-define ram offset=0x10003060 size=0x4   [ REG_GIF_TAG2              ]; # Bits 64-95 of tag before
-define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3              ]; # Bits 96-127 of tag before
-define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT               ]; # Transfer status counter
-define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT             ]; # PATH3 transfer status counter
-define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG             ]; # Bits 0-31 of PATH3 tag when interrupted
-define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO              ];
+define ram offset=0x10003000 size=0x4   [ REG_GIF_CTRL             ]; # Control register
+define ram offset=0x10003010 size=0x4   [ REG_GIF_MODE             ]; # Mode setting
+define ram offset=0x10003020 size=0x4   [ REG_GIF_STAT             ]; # Status
+define ram offset=0x10003040 size=0x4   [ REG_GIF_TAG0             ]; # Bits 0-31 of tag before
+define ram offset=0x10003050 size=0x4   [ REG_GIF_TAG1             ]; # Bits 32-63 of tag before
+define ram offset=0x10003060 size=0x4   [ REG_GIF_TAG2             ]; # Bits 64-95 of tag before
+define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3             ]; # Bits 96-127 of tag before
+define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT              ]; # Transfer status counter
+define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT            ]; # PATH3 transfer status counter
+define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG            ]; # Bits 0-31 of PATH3 tag when interrupted
+define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO             ];
 
 # DMA Controller (DMAC)
 
 # Channel 0
-define ram offset=0x10008000 size=0x4   [ REG_DMAC_0_VIF0_CHCR      ]; # Channel control
-define ram offset=0x10008010 size=0x4   [ REG_DMAC_0_VIF0_MADR      ]; # Channel address
-define ram offset=0x10008020 size=0x4   [ REG_DMAC_0_VIF0_QWC       ]; # Quadword count
-define ram offset=0x10008030 size=0x4   [ REG_DMAC_0_VIF0_TADR      ]; # Channel tag address
-define ram offset=0x10008040 size=0x4   [ REG_DMAC_0_VIF0_ASR0      ]; # Channel saved tag address
-define ram offset=0x10008050 size=0x4   [ REG_DMAC_0_VIF0_ASR1      ]; # Channel saved tag address
+define ram offset=0x10008000 size=0x4   [ REG_DMAC_0_VIF0_CHCR     ]; # Channel control
+define ram offset=0x10008010 size=0x4   [ REG_DMAC_0_VIF0_MADR     ]; # Channel address
+define ram offset=0x10008020 size=0x4   [ REG_DMAC_0_VIF0_QWC      ]; # Quadword count
+define ram offset=0x10008030 size=0x4   [ REG_DMAC_0_VIF0_TADR     ]; # Channel tag address
+define ram offset=0x10008040 size=0x4   [ REG_DMAC_0_VIF0_ASR0     ]; # Channel saved tag address
+define ram offset=0x10008050 size=0x4   [ REG_DMAC_0_VIF0_ASR1     ]; # Channel saved tag address
 
 # Channel 1
-define ram offset=0x10009000 size=0x4   [ REG_DMAC_1_VIF1_CHCR      ]; # Channel control
-define ram offset=0x10009010 size=0x4   [ REG_DMAC_1_VIF1_MADR      ]; # Channel address
-define ram offset=0x10009020 size=0x4   [ REG_DMAC_1_VIF1_QWC       ]; # Quadword count
-define ram offset=0x10009030 size=0x4   [ REG_DMAC_1_VIF1_TADR      ]; # Channel tag address
-define ram offset=0x10009040 size=0x4   [ REG_DMAC_1_VIF1_ASR0      ]; # Channel saved tag address
-define ram offset=0x10009050 size=0x4   [ REG_DMAC_1_VIF1_ASR1      ]; # Channel saved tag address
+define ram offset=0x10009000 size=0x4   [ REG_DMAC_1_VIF1_CHCR     ]; # Channel control
+define ram offset=0x10009010 size=0x4   [ REG_DMAC_1_VIF1_MADR     ]; # Channel address
+define ram offset=0x10009020 size=0x4   [ REG_DMAC_1_VIF1_QWC      ]; # Quadword count
+define ram offset=0x10009030 size=0x4   [ REG_DMAC_1_VIF1_TADR     ]; # Channel tag address
+define ram offset=0x10009040 size=0x4   [ REG_DMAC_1_VIF1_ASR0     ]; # Channel saved tag address
+define ram offset=0x10009050 size=0x4   [ REG_DMAC_1_VIF1_ASR1     ]; # Channel saved tag address
 
 # Channel 2
-define ram offset=0x1000A000 size=0x4   [ REG_DMAC_2_GIF_CHCR       ]; # Channel control
-define ram offset=0x1000A010 size=0x4   [ REG_DMAC_2_GIF_MADR       ]; # Channel address
-define ram offset=0x1000A020 size=0x4   [ REG_DMAC_2_GIF_QWC        ]; # Quadword count
-define ram offset=0x1000A030 size=0x4   [ REG_DMAC_2_GIF_TADR       ]; # Channel tag address
-define ram offset=0x1000A040 size=0x4   [ REG_DMAC_2_GIF_ASR0       ]; # Channel saved tag address
-define ram offset=0x1000A050 size=0x4   [ REG_DMAC_2_GIF_ASR1       ]; # Channel saved tag address
+define ram offset=0x1000A000 size=0x4   [ REG_DMAC_2_GIF_CHCR      ]; # Channel control
+define ram offset=0x1000A010 size=0x4   [ REG_DMAC_2_GIF_MADR      ]; # Channel address
+define ram offset=0x1000A020 size=0x4   [ REG_DMAC_2_GIF_QWC       ]; # Quadword count
+define ram offset=0x1000A030 size=0x4   [ REG_DMAC_2_GIF_TADR      ]; # Channel tag address
+define ram offset=0x1000A040 size=0x4   [ REG_DMAC_2_GIF_ASR0      ]; # Channel saved tag address
+define ram offset=0x1000A050 size=0x4   [ REG_DMAC_2_GIF_ASR1      ]; # Channel saved tag address
 
 # Channel 3
-define ram offset=0x1000B000 size=0x4   [ REG_DMAC_3_IPU_FROM_CHCR  ]; # Channel control
-define ram offset=0x1000B010 size=0x4   [ REG_DMAC_3_IPU_FROM_MADR  ]; # Channel address
-define ram offset=0x1000B020 size=0x4   [ REG_DMAC_3_IPU_FROM_QWC   ]; # Quadword count
-define ram offset=0x1000B030 size=0x4   [ REG_DMAC_3_IPU_FROM_TADR  ]; # Channel tag address
+define ram offset=0x1000B000 size=0x4   [ REG_DMAC_3_IPU_FROM_CHCR ]; # Channel control
+define ram offset=0x1000B010 size=0x4   [ REG_DMAC_3_IPU_FROM_MADR ]; # Channel address
+define ram offset=0x1000B020 size=0x4   [ REG_DMAC_3_IPU_FROM_QWC  ]; # Quadword count
+define ram offset=0x1000B030 size=0x4   [ REG_DMAC_3_IPU_FROM_TADR ]; # Channel tag address
 
 # Channel 4
-define ram offset=0x1000B400 size=0x4   [ REG_DMAC_4_IPU_TO_CHCR    ]; # Channel control
-define ram offset=0x1000B410 size=0x4   [ REG_DMAC_4_IPU_TO_MADR    ]; # Channel address
-define ram offset=0x1000B420 size=0x4   [ REG_DMAC_4_IPU_TO_QWC     ]; # Quadword count
-define ram offset=0x1000B430 size=0x4   [ REG_DMAC_4_IPU_TO_TADR    ]; # Channel tag address
+define ram offset=0x1000B400 size=0x4   [ REG_DMAC_4_IPU_TO_CHCR   ]; # Channel control
+define ram offset=0x1000B410 size=0x4   [ REG_DMAC_4_IPU_TO_MADR   ]; # Channel address
+define ram offset=0x1000B420 size=0x4   [ REG_DMAC_4_IPU_TO_QWC    ]; # Quadword count
+define ram offset=0x1000B430 size=0x4   [ REG_DMAC_4_IPU_TO_TADR   ]; # Channel tag address
 
 # Channel 5
-define ram offset=0x1000C000 size=0x4   [ REG_DMAC_5_SIF0_CHCR      ]; # Channel control
-define ram offset=0x1000C010 size=0x4   [ REG_DMAC_5_SIF0_MADR      ]; # Channel address
-define ram offset=0x1000C020 size=0x4   [ REG_DMAC_5_SIF0_QWC       ]; # Quadword count
-define ram offset=0x1000C030 size=0x4   [ REG_DMAC_5_SIF0_TADR      ]; # Channel tag address
+define ram offset=0x1000C000 size=0x4   [ REG_DMAC_5_SIF0_CHCR     ]; # Channel control
+define ram offset=0x1000C010 size=0x4   [ REG_DMAC_5_SIF0_MADR     ]; # Channel address
+define ram offset=0x1000C020 size=0x4   [ REG_DMAC_5_SIF0_QWC      ]; # Quadword count
+define ram offset=0x1000C030 size=0x4   [ REG_DMAC_5_SIF0_TADR     ]; # Channel tag address
 
 # Channel 6
-define ram offset=0x1000C400 size=0x4   [ REG_DMAC_6_SIF1_CHCR      ]; # Channel control
-define ram offset=0x1000C410 size=0x4   [ REG_DMAC_6_SIF1_MADR      ]; # Channel address
-define ram offset=0x1000C420 size=0x4   [ REG_DMAC_6_SIF1_QWC       ]; # Quadword count
-define ram offset=0x1000C430 size=0x4   [ REG_DMAC_6_SIF1_TADR      ]; # Channel tag address
+define ram offset=0x1000C400 size=0x4   [ REG_DMAC_6_SIF1_CHCR     ]; # Channel control
+define ram offset=0x1000C410 size=0x4   [ REG_DMAC_6_SIF1_MADR     ]; # Channel address
+define ram offset=0x1000C420 size=0x4   [ REG_DMAC_6_SIF1_QWC      ]; # Quadword count
+define ram offset=0x1000C430 size=0x4   [ REG_DMAC_6_SIF1_TADR     ]; # Channel tag address
 
 # Channel 7
-define ram offset=0x1000C800 size=0x4   [ REG_DMAC_7_SIF2_CHCR      ]; # Channel control
-define ram offset=0x1000C810 size=0x4   [ REG_DMAC_7_SIF2_MADR      ]; # Channel address
-define ram offset=0x1000C820 size=0x4   [ REG_DMAC_7_SIF2_QWC       ]; # Quadword count
-define ram offset=0x1000C830 size=0x4   [ REG_DMAC_7_SIF2_TADR      ]; # Channel tag address
+define ram offset=0x1000C800 size=0x4   [ REG_DMAC_7_SIF2_CHCR     ]; # Channel control
+define ram offset=0x1000C810 size=0x4   [ REG_DMAC_7_SIF2_MADR     ]; # Channel address
+define ram offset=0x1000C820 size=0x4   [ REG_DMAC_7_SIF2_QWC      ]; # Quadword count
+define ram offset=0x1000C830 size=0x4   [ REG_DMAC_7_SIF2_TADR     ]; # Channel tag address
 
 # Channel 8
-define ram offset=0x1000D000 size=0x4   [ REG_DMAC_8_SPR_FROM_CHCR  ]; # Channel control
-define ram offset=0x1000D010 size=0x4   [ REG_DMAC_8_SPR_FROM_MADR  ]; # Channel address
-define ram offset=0x1000D020 size=0x4   [ REG_DMAC_8_SPR_FROM_QWC   ]; # Quadword count
-define ram offset=0x1000D030 size=0x4   [ REG_DMAC_8_SPR_FROM_TADR  ]; # Channel tag address
-define ram offset=0x1000D080 size=0x4   [ REG_DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address
+define ram offset=0x1000D000 size=0x4   [ REG_DMAC_8_SPR_FROM_CHCR ]; # Channel control
+define ram offset=0x1000D010 size=0x4   [ REG_DMAC_8_SPR_FROM_MADR ]; # Channel address
+define ram offset=0x1000D020 size=0x4   [ REG_DMAC_8_SPR_FROM_QWC  ]; # Quadword count
+define ram offset=0x1000D030 size=0x4   [ REG_DMAC_8_SPR_FROM_TADR ]; # Channel tag address
+define ram offset=0x1000D080 size=0x4   [ REG_DMAC_8_SPR_FROM_SADR ]; # Channel scratchpad address
 
 # Channel 9
-define ram offset=0x1000D400 size=0x4   [ REG_DMAC_9_SPR_TO_CHCR    ]; # Channel control
-define ram offset=0x1000D410 size=0x4   [ REG_DMAC_9_SPR_TO_MADR    ]; # Channel address
-define ram offset=0x1000D420 size=0x4   [ REG_DMAC_9_SPR_TO_QWC     ]; # Quadword count
-define ram offset=0x1000D430 size=0x4   [ REG_DMAC_9_SPR_TO_TADR    ]; # Channel tag address
-define ram offset=0x1000D480 size=0x4   [ REG_DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address
+define ram offset=0x1000D400 size=0x4   [ REG_DMAC_9_SPR_TO_CHCR   ]; # Channel control
+define ram offset=0x1000D410 size=0x4   [ REG_DMAC_9_SPR_TO_MADR   ]; # Channel address
+define ram offset=0x1000D420 size=0x4   [ REG_DMAC_9_SPR_TO_QWC    ]; # Quadword count
+define ram offset=0x1000D430 size=0x4   [ REG_DMAC_9_SPR_TO_TADR   ]; # Channel tag address
+define ram offset=0x1000D480 size=0x4   [ REG_DMAC_9_SPR_TO_SADR   ]; # Channel scratchpad address
 
-define ram offset=0x1000E000 size=0x4   [ REG_DMAC_CTRL             ]; # DMAC control
-define ram offset=0x1000E010 size=0x4   [ REG_DMAC_STAT             ]; # DMAC interrupt status
-define ram offset=0x1000E020 size=0x4   [ REG_DMAC_PCR              ]; # DMAC priority control
-define ram offset=0x1000E030 size=0x4   [ REG_DMAC_SQWC             ]; # DMAC skip quadword
-define ram offset=0x1000E040 size=0x4   [ REG_DMAC_RBSR             ]; # DMAC ringbuffer size
-define ram offset=0x1000E050 size=0x4   [ REG_DMAC_RBOR             ]; # DMAC ringbuffer offset
-define ram offset=0x1000E060 size=0x4   [ REG_DMAC_STADR            ]; # DMAC stall address
-define ram offset=0x1000F520 size=0x4   [ REG_DMAC_ENABLER          ]; # DMAC disabled status
-define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW          ]; # DMAC disable
+define ram offset=0x1000E000 size=0x4   [ REG_DMAC_CTRL            ]; # DMAC control
+define ram offset=0x1000E010 size=0x4   [ REG_DMAC_STAT            ]; # DMAC interrupt status
+define ram offset=0x1000E020 size=0x4   [ REG_DMAC_PCR             ]; # DMAC priority control
+define ram offset=0x1000E030 size=0x4   [ REG_DMAC_SQWC            ]; # DMAC skip quadword
+define ram offset=0x1000E040 size=0x4   [ REG_DMAC_RBSR            ]; # DMAC ringbuffer size
+define ram offset=0x1000E050 size=0x4   [ REG_DMAC_RBOR            ]; # DMAC ringbuffer offset
+define ram offset=0x1000E060 size=0x4   [ REG_DMAC_STADR           ]; # DMAC stall address
+define ram offset=0x1000F520 size=0x4   [ REG_DMAC_ENABLER         ]; # DMAC disabled status
+define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW         ]; # DMAC disable
 
 # Interrupt Controller (INTC)
 
-define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT             ]; # Interrupt status
-define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK             ]; # Interrupt mask
+define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT            ]; # Interrupt status
+define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK            ]; # Interrupt mask
 
 # Subsystem Interface (SIF)
 
-define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM             ]; # EE->IOP communication
-define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM             ]; # IOP->EE communication
-define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG            ]; # EE->IOP flags
-define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG            ]; # IOP->EE flags
-define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL           ]; # Control register
+define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM            ]; # EE->IOP communication
+define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM            ]; # IOP->EE communication
+define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG           ]; # EE->IOP flags
+define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG           ]; # IOP->EE flags
+define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL          ]; # Control register
 
 # Privileged GS registers
 
-define ram offset=0x12000000 size=0x8   [ REG_GS_PMODE              ]; # various PCRTC controls
-define ram offset=0x12000010 size=0x8   [ REG_GS_SMODE1             ];
-define ram offset=0x12000020 size=0x8   [ REG_GS_SMODE2             ];
-define ram offset=0x12000030 size=0x8   [ REG_GS_SRFSH              ];
-define ram offset=0x12000040 size=0x8   [ REG_GS_SYNCH1             ];
-define ram offset=0x12000050 size=0x8   [ REG_GS_SYNCH2             ];
-define ram offset=0x12000060 size=0x8   [ REG_GS_SYNCV              ];
-define ram offset=0x12000070 size=0x8   [ REG_GS_DISPFB1            ]; # display buffer for output circuit 1
-define ram offset=0x12000080 size=0x8   [ REG_GS_DISPLAY1           ]; # output circuit 1 control
-define ram offset=0x12000090 size=0x8   [ REG_GS_DISPFB2            ]; # display buffer for output circuit 2
-define ram offset=0x120000A0 size=0x8   [ REG_GS_DISPLAY2           ]; # output circuit 2 control
-define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF             ];
-define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA            ];
-define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE           ];
-define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR            ]; # background color
-define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR             ]; # control register
-define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR             ]; # GS interrupt control
-define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR             ]; # transfer direction
-define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID           ]; # signal
+define ram offset=0x12000000 size=0x8   [ REG_GS_PMODE             ]; # various PCRTC controls
+define ram offset=0x12000010 size=0x8   [ REG_GS_SMODE1            ];
+define ram offset=0x12000020 size=0x8   [ REG_GS_SMODE2            ];
+define ram offset=0x12000030 size=0x8   [ REG_GS_SRFSH             ];
+define ram offset=0x12000040 size=0x8   [ REG_GS_SYNCH1            ];
+define ram offset=0x12000050 size=0x8   [ REG_GS_SYNCH2            ];
+define ram offset=0x12000060 size=0x8   [ REG_GS_SYNCV             ];
+define ram offset=0x12000070 size=0x8   [ REG_GS_DISPFB1           ]; # display buffer for output circuit 1
+define ram offset=0x12000080 size=0x8   [ REG_GS_DISPLAY1          ]; # output circuit 1 control
+define ram offset=0x12000090 size=0x8   [ REG_GS_DISPFB2           ]; # display buffer for output circuit 2
+define ram offset=0x120000A0 size=0x8   [ REG_GS_DISPLAY2          ]; # output circuit 2 control
+define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF            ];
+define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA           ];
+define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE          ];
+define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR           ]; # background color
+define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR            ]; # control register
+define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR            ]; # GS interrupt control
+define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR            ]; # transfer direction
+define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID          ]; # signal

--- a/data/languages/mmio.sinc
+++ b/data/languages/mmio.sinc
@@ -10,138 +10,138 @@ define ram offset=0x10001800 size=0x100 [ REG_TIMER3 ];
 
 # Image Processing Unit (IPU)
 
-define ram offset=0x10002000 size=0x8   [ REG_IPU_COMMAND ];
-define ram offset=0x10002010 size=0x4   [ REG_IPU_CONTROL ];
+define ram offset=0x10002000 size=0x8   [ REG_IPU_COMMAND             ];
+define ram offset=0x10002010 size=0x4   [ REG_IPU_CONTROL             ];
 define ram offset=0x10002020 size=0x4   [ REG_IPU_BIT_POINTER_CONTROL ];
-define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP_OF_BITSTREAM ];
-define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO_READ ];
-define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO_WRITE ];
+define ram offset=0x10002030 size=0x8   [ REG_IPU_TOP_OF_BITSTREAM    ];
+define ram offset=0x10007000 size=0x10  [ REG_IPU_OUT_FIFO_READ       ];
+define ram offset=0x10007010 size=0x10  [ REG_IPU_IN_FIFO_WRITE       ];
 
 # Graphics Interface (GIF)
 
-define ram offset=0x10003000 size=0x4   [ REG_GIF_CTRL ];
-define ram offset=0x10003010 size=0x4   [ REG_GIF_MODE ];
-define ram offset=0x10003020 size=0x4   [ REG_GIF_STAT ];
-define ram offset=0x10003040 size=0x4   [ REG_GIF_TAG0 ];
-define ram offset=0x10003050 size=0x4   [ REG_GIF_TAG1 ];
-define ram offset=0x10003060 size=0x4   [ REG_GIF_TAG2 ];
-define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3 ];
-define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT ];
-define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT ];
-define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG ];
-define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO ];
+define ram offset=0x10003000 size=0x4   [ REG_GIF_CTRL              ]; # Control register
+define ram offset=0x10003010 size=0x4   [ REG_GIF_MODE              ]; # Mode setting
+define ram offset=0x10003020 size=0x4   [ REG_GIF_STAT              ]; # Status
+define ram offset=0x10003040 size=0x4   [ REG_GIF_TAG0              ]; # Bits 0-31 of tag before
+define ram offset=0x10003050 size=0x4   [ REG_GIF_TAG1              ]; # Bits 32-63 of tag before
+define ram offset=0x10003060 size=0x4   [ REG_GIF_TAG2              ]; # Bits 64-95 of tag before
+define ram offset=0x10003070 size=0x4   [ REG_GIF_TAG3              ]; # Bits 96-127 of tag before
+define ram offset=0x10003080 size=0x4   [ REG_GIF_CNT               ]; # Transfer status counter
+define ram offset=0x10003090 size=0x4   [ REG_GIF_P3CNT             ]; # PATH3 transfer status counter
+define ram offset=0x100030A0 size=0x4   [ REG_GIF_P3TAG             ]; # Bits 0-31 of PATH3 tag when interrupted
+define ram offset=0x10006000 size=0x10  [ REG_GIF_FIFO              ];
 
 # DMA Controller (DMAC)
 
 # Channel 0
-define ram offset=0x10008000 size=0x4   [ REG_DMAC_0_VIF0_CHCR      ]; # Channel control.
-define ram offset=0x10008010 size=0x4   [ REG_DMAC_0_VIF0_MADR      ]; # Channel address.
-define ram offset=0x10008020 size=0x4   [ REG_DMAC_0_VIF0_QWC       ]; # Quadword count.
-define ram offset=0x10008030 size=0x4   [ REG_DMAC_0_VIF0_TADR      ]; # Channel tag address.
-define ram offset=0x10008040 size=0x4   [ REG_DMAC_0_VIF0_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x10008050 size=0x4   [ REG_DMAC_0_VIF0_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10008000 size=0x4   [ REG_DMAC_0_VIF0_CHCR      ]; # Channel control
+define ram offset=0x10008010 size=0x4   [ REG_DMAC_0_VIF0_MADR      ]; # Channel address
+define ram offset=0x10008020 size=0x4   [ REG_DMAC_0_VIF0_QWC       ]; # Quadword count
+define ram offset=0x10008030 size=0x4   [ REG_DMAC_0_VIF0_TADR      ]; # Channel tag address
+define ram offset=0x10008040 size=0x4   [ REG_DMAC_0_VIF0_ASR0      ]; # Channel saved tag address
+define ram offset=0x10008050 size=0x4   [ REG_DMAC_0_VIF0_ASR1      ]; # Channel saved tag address
 
 # Channel 1
-define ram offset=0x10009000 size=0x4   [ REG_DMAC_1_VIF1_CHCR      ]; # Channel control.
-define ram offset=0x10009010 size=0x4   [ REG_DMAC_1_VIF1_MADR      ]; # Channel address.
-define ram offset=0x10009020 size=0x4   [ REG_DMAC_1_VIF1_QWC       ]; # Quadword count.
-define ram offset=0x10009030 size=0x4   [ REG_DMAC_1_VIF1_TADR      ]; # Channel tag address.
-define ram offset=0x10009040 size=0x4   [ REG_DMAC_1_VIF1_ASR0      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x10009050 size=0x4   [ REG_DMAC_1_VIF1_ASR1      ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x10009000 size=0x4   [ REG_DMAC_1_VIF1_CHCR      ]; # Channel control
+define ram offset=0x10009010 size=0x4   [ REG_DMAC_1_VIF1_MADR      ]; # Channel address
+define ram offset=0x10009020 size=0x4   [ REG_DMAC_1_VIF1_QWC       ]; # Quadword count
+define ram offset=0x10009030 size=0x4   [ REG_DMAC_1_VIF1_TADR      ]; # Channel tag address
+define ram offset=0x10009040 size=0x4   [ REG_DMAC_1_VIF1_ASR0      ]; # Channel saved tag address
+define ram offset=0x10009050 size=0x4   [ REG_DMAC_1_VIF1_ASR1      ]; # Channel saved tag address
 
 # Channel 2
-define ram offset=0x1000A000 size=0x4   [ REG_DMAC_2_GIF_CHCR       ]; # Channel control.
-define ram offset=0x1000A010 size=0x4   [ REG_DMAC_2_GIF_MADR       ]; # Channel address.
-define ram offset=0x1000A020 size=0x4   [ REG_DMAC_2_GIF_QWC        ]; # Quadword count.
-define ram offset=0x1000A030 size=0x4   [ REG_DMAC_2_GIF_TADR       ]; # Channel tag address.
-define ram offset=0x1000A040 size=0x4   [ REG_DMAC_2_GIF_ASR0       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
-define ram offset=0x1000A050 size=0x4   [ REG_DMAC_2_GIF_ASR1       ]; # Channel saved tag address. Only used by the VIF0, VIF1, and GIF channels.
+define ram offset=0x1000A000 size=0x4   [ REG_DMAC_2_GIF_CHCR       ]; # Channel control
+define ram offset=0x1000A010 size=0x4   [ REG_DMAC_2_GIF_MADR       ]; # Channel address
+define ram offset=0x1000A020 size=0x4   [ REG_DMAC_2_GIF_QWC        ]; # Quadword count
+define ram offset=0x1000A030 size=0x4   [ REG_DMAC_2_GIF_TADR       ]; # Channel tag address
+define ram offset=0x1000A040 size=0x4   [ REG_DMAC_2_GIF_ASR0       ]; # Channel saved tag address
+define ram offset=0x1000A050 size=0x4   [ REG_DMAC_2_GIF_ASR1       ]; # Channel saved tag address
 
 # Channel 3
-define ram offset=0x1000B000 size=0x4   [ REG_DMAC_3_IPU_FROM_CHCR  ]; # Channel control.
-define ram offset=0x1000B010 size=0x4   [ REG_DMAC_3_IPU_FROM_MADR  ]; # Channel address.
-define ram offset=0x1000B020 size=0x4   [ REG_DMAC_3_IPU_FROM_QWC   ]; # Quadword count.
-define ram offset=0x1000B030 size=0x4   [ REG_DMAC_3_IPU_FROM_TADR  ]; # Channel tag address.
+define ram offset=0x1000B000 size=0x4   [ REG_DMAC_3_IPU_FROM_CHCR  ]; # Channel control
+define ram offset=0x1000B010 size=0x4   [ REG_DMAC_3_IPU_FROM_MADR  ]; # Channel address
+define ram offset=0x1000B020 size=0x4   [ REG_DMAC_3_IPU_FROM_QWC   ]; # Quadword count
+define ram offset=0x1000B030 size=0x4   [ REG_DMAC_3_IPU_FROM_TADR  ]; # Channel tag address
 
 # Channel 4
-define ram offset=0x1000B400 size=0x4   [ REG_DMAC_4_IPU_TO_CHCR    ]; # Channel control.
-define ram offset=0x1000B410 size=0x4   [ REG_DMAC_4_IPU_TO_MADR    ]; # Channel address.
-define ram offset=0x1000B420 size=0x4   [ REG_DMAC_4_IPU_TO_QWC     ]; # Quadword count.
-define ram offset=0x1000B430 size=0x4   [ REG_DMAC_4_IPU_TO_TADR    ]; # Channel tag address.
+define ram offset=0x1000B400 size=0x4   [ REG_DMAC_4_IPU_TO_CHCR    ]; # Channel control
+define ram offset=0x1000B410 size=0x4   [ REG_DMAC_4_IPU_TO_MADR    ]; # Channel address
+define ram offset=0x1000B420 size=0x4   [ REG_DMAC_4_IPU_TO_QWC     ]; # Quadword count
+define ram offset=0x1000B430 size=0x4   [ REG_DMAC_4_IPU_TO_TADR    ]; # Channel tag address
 
 # Channel 5
-define ram offset=0x1000C000 size=0x4   [ REG_DMAC_5_SIF0_CHCR      ]; # Channel control.
-define ram offset=0x1000C010 size=0x4   [ REG_DMAC_5_SIF0_MADR      ]; # Channel address.
-define ram offset=0x1000C020 size=0x4   [ REG_DMAC_5_SIF0_QWC       ]; # Quadword count.
-define ram offset=0x1000C030 size=0x4   [ REG_DMAC_5_SIF0_TADR      ]; # Channel tag address.
+define ram offset=0x1000C000 size=0x4   [ REG_DMAC_5_SIF0_CHCR      ]; # Channel control
+define ram offset=0x1000C010 size=0x4   [ REG_DMAC_5_SIF0_MADR      ]; # Channel address
+define ram offset=0x1000C020 size=0x4   [ REG_DMAC_5_SIF0_QWC       ]; # Quadword count
+define ram offset=0x1000C030 size=0x4   [ REG_DMAC_5_SIF0_TADR      ]; # Channel tag address
 
 # Channel 6
-define ram offset=0x1000C400 size=0x4   [ REG_DMAC_6_SIF1_CHCR      ]; # Channel control.
-define ram offset=0x1000C410 size=0x4   [ REG_DMAC_6_SIF1_MADR      ]; # Channel address.
-define ram offset=0x1000C420 size=0x4   [ REG_DMAC_6_SIF1_QWC       ]; # Quadword count.
-define ram offset=0x1000C430 size=0x4   [ REG_DMAC_6_SIF1_TADR      ]; # Channel tag address.
+define ram offset=0x1000C400 size=0x4   [ REG_DMAC_6_SIF1_CHCR      ]; # Channel control
+define ram offset=0x1000C410 size=0x4   [ REG_DMAC_6_SIF1_MADR      ]; # Channel address
+define ram offset=0x1000C420 size=0x4   [ REG_DMAC_6_SIF1_QWC       ]; # Quadword count
+define ram offset=0x1000C430 size=0x4   [ REG_DMAC_6_SIF1_TADR      ]; # Channel tag address
 
 # Channel 7
-define ram offset=0x1000C800 size=0x4   [ REG_DMAC_7_SIF2_CHCR      ]; # Channel control.
-define ram offset=0x1000C810 size=0x4   [ REG_DMAC_7_SIF2_MADR      ]; # Channel address.
-define ram offset=0x1000C820 size=0x4   [ REG_DMAC_7_SIF2_QWC       ]; # Quadword count.
-define ram offset=0x1000C830 size=0x4   [ REG_DMAC_7_SIF2_TADR      ]; # Channel tag address.
+define ram offset=0x1000C800 size=0x4   [ REG_DMAC_7_SIF2_CHCR      ]; # Channel control
+define ram offset=0x1000C810 size=0x4   [ REG_DMAC_7_SIF2_MADR      ]; # Channel address
+define ram offset=0x1000C820 size=0x4   [ REG_DMAC_7_SIF2_QWC       ]; # Quadword count
+define ram offset=0x1000C830 size=0x4   [ REG_DMAC_7_SIF2_TADR      ]; # Channel tag address
 
 # Channel 8
-define ram offset=0x1000D000 size=0x4   [ REG_DMAC_8_SPR_FROM_CHCR  ]; # Channel control.
-define ram offset=0x1000D010 size=0x4   [ REG_DMAC_8_SPR_FROM_MADR  ]; # Channel address.
-define ram offset=0x1000D020 size=0x4   [ REG_DMAC_8_SPR_FROM_QWC   ]; # Quadword count.
-define ram offset=0x1000D030 size=0x4   [ REG_DMAC_8_SPR_FROM_TADR  ]; # Channel tag address.
-define ram offset=0x1000D080 size=0x4   [ REG_DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+define ram offset=0x1000D000 size=0x4   [ REG_DMAC_8_SPR_FROM_CHCR  ]; # Channel control
+define ram offset=0x1000D010 size=0x4   [ REG_DMAC_8_SPR_FROM_MADR  ]; # Channel address
+define ram offset=0x1000D020 size=0x4   [ REG_DMAC_8_SPR_FROM_QWC   ]; # Quadword count
+define ram offset=0x1000D030 size=0x4   [ REG_DMAC_8_SPR_FROM_TADR  ]; # Channel tag address
+define ram offset=0x1000D080 size=0x4   [ REG_DMAC_8_SPR_FROM_SADR  ]; # Channel scratchpad address
 
 # Channel 9
-define ram offset=0x1000D400 size=0x4   [ REG_DMAC_9_SPR_TO_CHCR    ]; # Channel control.
-define ram offset=0x1000D410 size=0x4   [ REG_DMAC_9_SPR_TO_MADR    ]; # Channel address.
-define ram offset=0x1000D420 size=0x4   [ REG_DMAC_9_SPR_TO_QWC     ]; # Quadword count.
-define ram offset=0x1000D430 size=0x4   [ REG_DMAC_9_SPR_TO_TADR    ]; # Channel tag address.
-define ram offset=0x1000D480 size=0x4   [ REG_DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address. Only used by SPR_FROM and SPR_TO.
+define ram offset=0x1000D400 size=0x4   [ REG_DMAC_9_SPR_TO_CHCR    ]; # Channel control
+define ram offset=0x1000D410 size=0x4   [ REG_DMAC_9_SPR_TO_MADR    ]; # Channel address
+define ram offset=0x1000D420 size=0x4   [ REG_DMAC_9_SPR_TO_QWC     ]; # Quadword count
+define ram offset=0x1000D430 size=0x4   [ REG_DMAC_9_SPR_TO_TADR    ]; # Channel tag address
+define ram offset=0x1000D480 size=0x4   [ REG_DMAC_9_SPR_TO_SADR    ]; # Channel scratchpad address
 
-define ram offset=0x1000E000 size=0x4   [ REG_DMAC_CTRL ];
-define ram offset=0x1000E010 size=0x4   [ REG_DMAC_STAT ];
-define ram offset=0x1000E020 size=0x4   [ REG_DMAC_PCR ];
-define ram offset=0x1000E030 size=0x4   [ REG_DMAC_SQWC ];
-define ram offset=0x1000E040 size=0x4   [ REG_DMAC_RBSR ];
-define ram offset=0x1000E050 size=0x4   [ REG_DMAC_RBOR ];
-define ram offset=0x1000E060 size=0x4   [ REG_DMAC_STADR ];
-define ram offset=0x1000F520 size=0x4   [ REG_DMAC_ENABLER ];
-define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW ];
+define ram offset=0x1000E000 size=0x4   [ REG_DMAC_CTRL             ]; # DMAC control
+define ram offset=0x1000E010 size=0x4   [ REG_DMAC_STAT             ]; # DMAC interrupt status
+define ram offset=0x1000E020 size=0x4   [ REG_DMAC_PCR              ]; # DMAC priority control
+define ram offset=0x1000E030 size=0x4   [ REG_DMAC_SQWC             ]; # DMAC skip quadword
+define ram offset=0x1000E040 size=0x4   [ REG_DMAC_RBSR             ]; # DMAC ringbuffer size
+define ram offset=0x1000E050 size=0x4   [ REG_DMAC_RBOR             ]; # DMAC ringbuffer offset
+define ram offset=0x1000E060 size=0x4   [ REG_DMAC_STADR            ]; # DMAC stall address
+define ram offset=0x1000F520 size=0x4   [ REG_DMAC_ENABLER          ]; # DMAC disabled status
+define ram offset=0x1000F590 size=0x4   [ REG_DMAC_ENABLEW          ]; # DMAC disable
 
 # Interrupt Controller (INTC)
 
-define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT ];
-define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK ];
+define ram offset=0x1000F000 size=0x4   [ REG_INTC_STAT             ]; # Interrupt status
+define ram offset=0x1000F010 size=0x4   [ REG_INTC_MASK             ]; # Interrupt mask
 
 # Subsystem Interface (SIF)
 
-define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM ];
-define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM ];
-define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG ];
-define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG ];
-define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL ];
+define ram offset=0x1000F200 size=0x4   [ REG_SIF_MSCOM             ]; # EE->IOP communication
+define ram offset=0x1000F210 size=0x4   [ REG_SIF_SMCOM             ]; # IOP->EE communication
+define ram offset=0x1000F220 size=0x4   [ REG_SIF_MSFLAG            ]; # EE->IOP flags
+define ram offset=0x1000F230 size=0x4   [ REG_SIF_SMFLAG            ]; # IOP->EE flags
+define ram offset=0x1000F240 size=0x4   [ REG_SIF_CONTROL           ]; # Control register
 
 # Privileged GS registers
 
-define ram offset=0x12000000 size=0x8   [ REG_GS_PMODE ];
-define ram offset=0x12000010 size=0x8   [ REG_GS_SMODE1 ];
-define ram offset=0x12000020 size=0x8   [ REG_GS_SMODE2 ];
-define ram offset=0x12000030 size=0x8   [ REG_GS_SRFSH ];
-define ram offset=0x12000040 size=0x8   [ REG_GS_SYNCH1 ];
-define ram offset=0x12000050 size=0x8   [ REG_GS_SYNCH2 ];
-define ram offset=0x12000060 size=0x8   [ REG_GS_SYNCV ];
-define ram offset=0x12000070 size=0x8   [ REG_GS_DISPFB1 ];
-define ram offset=0x12000080 size=0x8   [ REG_GS_DISPLAY1 ];
-define ram offset=0x12000090 size=0x8   [ REG_GS_DISPFB2 ];
-define ram offset=0x120000A0 size=0x8   [ REG_GS_DISPLAY2 ];
-define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF ];
-define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA ];
-define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE ];
-define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR ];
-define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR ];
-define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR ];
-define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR ];
-define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID ];
+define ram offset=0x12000000 size=0x8   [ REG_GS_PMODE              ]; # various PCRTC controls
+define ram offset=0x12000010 size=0x8   [ REG_GS_SMODE1             ];
+define ram offset=0x12000020 size=0x8   [ REG_GS_SMODE2             ];
+define ram offset=0x12000030 size=0x8   [ REG_GS_SRFSH              ];
+define ram offset=0x12000040 size=0x8   [ REG_GS_SYNCH1             ];
+define ram offset=0x12000050 size=0x8   [ REG_GS_SYNCH2             ];
+define ram offset=0x12000060 size=0x8   [ REG_GS_SYNCV              ];
+define ram offset=0x12000070 size=0x8   [ REG_GS_DISPFB1            ]; # display buffer for output circuit 1
+define ram offset=0x12000080 size=0x8   [ REG_GS_DISPLAY1           ]; # output circuit 1 control
+define ram offset=0x12000090 size=0x8   [ REG_GS_DISPFB2            ]; # display buffer for output circuit 2
+define ram offset=0x120000A0 size=0x8   [ REG_GS_DISPLAY2           ]; # output circuit 2 control
+define ram offset=0x120000B0 size=0x8   [ REG_GS_EXTBUF             ];
+define ram offset=0x120000C0 size=0x8   [ REG_GS_EXTDATA            ];
+define ram offset=0x120000D0 size=0x8   [ REG_GS_EXTWRITE           ];
+define ram offset=0x120000E0 size=0x8   [ REG_GS_BGCOLOR            ]; # background color
+define ram offset=0x12001000 size=0x8   [ REG_GS_GS_CSR             ]; # control register
+define ram offset=0x12001010 size=0x8   [ REG_GS_GS_IMR             ]; # GS interrupt control
+define ram offset=0x12001040 size=0x8   [ REG_GS_BUSDIR             ]; # transfer direction
+define ram offset=0x12001080 size=0x8   [ REG_GS_SIGLBLID           ]; # signal

--- a/data/languages/r5900.slaspec
+++ b/data/languages/r5900.slaspec
@@ -19,3 +19,4 @@ define space register type=register_space size=4;
 @include "cop0.sinc"
 @include "cop1.sinc"
 @include "cop2.sinc"
+@include "mmio.sinc"

--- a/ghidra_scripts/ImportMMIORegisterLabels.java
+++ b/ghidra_scripts/ImportMMIORegisterLabels.java
@@ -1,0 +1,48 @@
+// Create a label for each MMIO register in a namespace called "registers".
+//@category ghidra-emotionengine
+
+import ghidra.app.script.GhidraScript;
+import ghidra.program.model.util.*;
+import ghidra.program.model.reloc.*;
+import ghidra.program.model.data.*;
+import ghidra.program.model.block.*;
+import ghidra.program.model.symbol.*;
+import ghidra.program.model.scalar.*;
+import ghidra.program.model.mem.*;
+import ghidra.program.model.listing.*;
+import ghidra.program.model.lang.*;
+import ghidra.program.model.pcode.*;
+import ghidra.program.model.address.*;
+
+public class ImportMMIORegisterLabels extends GhidraScript {
+
+    public void run() throws Exception {
+        Namespace registerNamespace = getNamespace(null, "registers");
+        if(registerNamespace == null) {
+            registerNamespace = currentProgram.getSymbolTable().createNameSpace(
+                currentProgram.getGlobalNamespace(),
+                "registers",
+                SourceType.USER_DEFINED
+            );
+        }
+        
+        AddressSpace ram = currentProgram.getAddressFactory().getAddressSpace("ram");
+        Register[] registers = currentProgram.getLanguage().getRegisters();
+        for(Register register : registers) {
+            if(register.getAddressSpace() == ram) {
+                Symbol[] oldSymbols = currentProgram.getSymbolTable().getSymbols(register.getAddress());
+                for(Symbol symbol : oldSymbols) {
+                    symbol.delete();
+                }
+                
+                currentProgram.getSymbolTable().createLabel(
+                    register.getAddress(),
+                    register.getName(),
+                    registerNamespace,
+                    SourceType.USER_DEFINED
+                );
+            }
+        }
+    }
+
+}


### PR DESCRIPTION
This PR defines MMIO registers that were previously not recognized. I used https://psi-rockin.github.io/ps2tek/ as a reference.

The register names appear nicely in the decompilation. For example, a piece of code that would have previously been decompiled to:
> write_volatile_4(0x1000d000,0x100);

Will now decompile to:
> write_volatile_4(REG_DMAC_8_SPR_FROM_CHCR,0x100);

Ghidra assigns each of these registers a label when creating a new project. This can clutter up the symbol tree, so as a workaround I've included a script that re-imports these labels in their own namespace and deletes the old labels. This is also useful if you have an existing project, where the labels won't be generated automatically. If you have a better solution, please tell me.