### PR TITLE
Add separate `b` disassembly

### DIFF
--- a/data/languages/mips.sinc
+++ b/data/languages/mips.sinc
@@ -50,6 +50,13 @@ define pcodeop syscall;
     }
 
     # 0001 00ss ssst tttt iiii iiii iiii iiii
+    # Special case of beq
+    :b Rel16        		                is prime=4 & rs = 0 & rt = 0 & Rel16 {
+        delayslot( 1 );
+        goto Rel16;
+    }
+
+    # 0001 00ss ssst tttt iiii iiii iiii iiii
     :beq RSsrc, RTsrc, Rel16        		is prime=4 & RSsrc & RTsrc & Rel16 {
         delayflag:1 = ( RSsrc == RTsrc );
         delayslot( 1 );


### PR DESCRIPTION
Ghidra's decompiler can be dumb and not realize `if (true) goto x` can't fall through, breaking instruction reordering past the branch

This works around it by manually adding a separate `b` decoding for `beq zero, zero`

[Example file that decompiles stupidly](https://github.com/beardypig/ghidra-emotionengine/files/5861600/mipsfn.gz)

Example file decompiled with beq:
<img width="688" alt="Example file decompiled with beq" src="https://user-images.githubusercontent.com/3315070/105621710-11507b80-5dd0-11eb-9bb7-bd0d61e29a0d.png">


Example file decompiled with b:
<img width="687" alt="Example file decompiled with b" src="https://user-images.githubusercontent.com/3315070/105621724-3b09a280-5dd0-11eb-9eae-94e7c655e6ae.png">
