### PR TITLE
Fix build and add Ghidra 9.2.3 support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,11 +22,11 @@ jobs:
           version: ${{ matrix.ghidra }}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: current
+          gradle-version: 6.9
           arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: current
+          gradle-version: 6.9
           arguments: buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
       - uses: svenstaro/upload-release-action@v1-release
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -23,11 +23,11 @@ jobs:
           version: ${{ matrix.ghidra }}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: current
+          gradle-version: 6.9
           arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: current
+          gradle-version: 6.9
           arguments: buildExtension -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}
       - uses: svenstaro/upload-release-action@v1-release
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,5 +20,5 @@ jobs:
           version: ${{ matrix.ghidra }}
       - uses: eskatos/gradle-command-action@v1
         with:
-          gradle-version: current
+          gradle-version: 6.9
           arguments: test -PGHIDRA_INSTALL_DIR=${{ env.GHIDRA_INSTALL_DIR }}


### PR DESCRIPTION
- Fix build by pinning Gradle version in workflow files.
  - Ghidra currently requires Gradle 5.x or 6.x. Support for newer Gradle versions will be added with Ghidra 9.3, see https://github.com/NationalSecurityAgency/ghidra/issues/2949.
- Add Ghidra 9.2.3 to strategy matrices in workflow files.