### PR TITLE
Add Ghidra 9.2.4 support

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3", "9.2.4"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3", "9.2.4"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3"]
+        ghidra: ["9.2", "9.2.1", "9.2.2", "9.2.3", "9.2.4"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1


### PR DESCRIPTION
Some more progress on #64 (was already partially done by #60).

I originally also wanted to add 10.0-BETA support, too, but https://github.com/er28-0652/setup-ghidra does not seem to support it.