### PR TITLE
Update Github Actions workflows to build for all versions since 10.0.3

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra:  ["10.0", "10.0.1", "10.0.2", "10.0.3"]
+        ghidra:  ["10.0", "10.0.1", "10.0.2", "10.0.3", "10.0.4", "10.1", "10.1.1", "10.1.2", "10.1.3", "10.1.4", "10.1.5"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ghidra:  ["10.0", "10.0.1", "10.0.2", "10.0.3"]
+        ghidra:  ["10.0", "10.0.1", "10.0.2", "10.0.3", "10.0.4", "10.1", "10.1.1", "10.1.2", "10.1.3", "10.1.4", "10.1.5"]
     steps:
       - uses: actions/checkout@v1
       - uses: actions/setup-java@v1


### PR DESCRIPTION
As title says, this PR updates the `publish.yml` and `nightly.yml` workflow files to build for more recent builds of Ghidra.